### PR TITLE
update test to specify laravel 5.1 since app.php is from 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
 
 before_install:
   - composer self-update
-  - composer create-project laravel/laravel
+  - composer create-project laravel/laravel=5.1.11
   - cd ./laravel
   - composer require comocode/laravel-ab dev-master
   - composer update


### PR DESCRIPTION
updating test to fix ab:migrate error on travis
https://travis-ci.org/comocode/laravel-ab/jobs/115569946
caused by app.php being incompatible with 5.2

Must find a way to dynamically inject service providers to avoid conflicts in the future and test current versions. 
