### PR TITLE
Fixed duplicate instance bug

### DIFF
--- a/src/App/Instance.php
+++ b/src/App/Instance.php
@@ -14,7 +14,7 @@ class Instance extends \Eloquent {
     }
 
     public function setMetadataAttribute($value){
-        $this->attributes['metadata']=serialize($value);
+        $this->attributes['metadata'] = is_null($value) ? null : serialize($value);
     }
 
     public function getMetadataAttribute($value){


### PR DESCRIPTION
Fixed bug where firstOrCreate (Ab.php line 63) could not find the instance because metadata was serialized as N; instead of storing NULL.
